### PR TITLE
Add vscode settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+# Visual Studio Code's Setings directory
+# Dev Note: VS Code basically already gives you everything you need when opening
+#   From Extensions, Launch and Build params.
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
Adds VS Code to the Git Ignore list.

As noted in the comment, VS Code opening basically does all the work for you:

Opening the project will suggest to download the .Net and C# Plugins.
Once they're downloaded hitting F5 will generate the Launch + Build files for VS Code to Build and Debug the application.

There's no Publish option but this isn't as needed~